### PR TITLE
[Fix] Error raised when using "linear" policy

### DIFF
--- a/clr.py
+++ b/clr.py
@@ -274,7 +274,7 @@ class LRFinder(Callback):
         self.save_dir = save_dir
         self.verbose = verbose
 
-        self.num_batches_ = num_samples // batch_size - 1
+        self.num_batches_ = num_samples // batch_size
         self.current_lr_ = minimum_lr
 
         if lr_scale == 'exp':


### PR DESCRIPTION
This fixes the "list out of bounds" exception raised when searching with "linear" policy. The error was raised due to a mismatch between the number of batches and the length of `lr_multiplier_`.
Note that this fix does not affect anything else.

For a detailed discussion, please refer to #6 